### PR TITLE
Update BitQuest.java

### DIFF
--- a/src/main/java/com/bitquest/bitquest/BitQuest.java
+++ b/src/main/java/com/bitquest/bitquest/BitQuest.java
@@ -560,6 +560,7 @@ public class  BitQuest extends JavaPlugin {
                             // Abandon land
                             BitQuest.REDIS.del("chunk" + x + "," + z + "owner");
                             BitQuest.REDIS.del("chunk" + x + "," + z + "name");
+                            BitQuest.REDIS.del("chunk" + x+","+z+"permissions");
                         } else if (name.startsWith("transfer ") && name.length() > 9) {
                             // If the name starts with "transfer " and has at least one more character,
                             // transfer land


### PR DESCRIPTION
added:
                            BitQuest.REDIS.del("chunk" + x+","+z+"permissions");
to fix abandon claims that stay private with no owner