### PR TITLE
Maven travis check style allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 matrix:
   include:
     - script: mvn checkstyle:check -B
-mvn checkstyle:
+
   allow_failures:
     - script: mvn checkstyle:check -B
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 matrix:
   include:
     - script: mvn checkstyle:check -B
-mvn checkstyle:check -B
+mvn checkstyle:
   allow_failures:
     - script: mvn checkstyle:check -B
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ os:
   linux
 
 env:
+
 matrix:
   include:
-    - script:
-      mvn checkstyle:check -B
+    - script: mvn checkstyle:check -B
+mvn checkstyle:check -B
   allow_failures:
-    - script:
-      mvn checkstyle:check -B
+    - script: mvn checkstyle:check -B
+
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ jdk:
 os:
   linux
 
+env:
+matrix:
+  include:
+    - script:
+      mvn checkstyle:check -B
+  allow_failure:
+    - script:
+      mvn checkstyle:check -B
+
 cache:
   directories:
     $HOME/.m2/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   include:
     - script:
       mvn checkstyle:check -B
-  allow_failure:
+  allow_failures:
     - script:
       mvn checkstyle:check -B
 


### PR DESCRIPTION
Now Travis will generate 2 task, the classic compilation task and the checkstyle task (this task can fail, this will not change the result (the result is if the compilation task fail or not)).
I will change the style check in the future, it is too difficult.